### PR TITLE
Update to Working Build

### DIFF
--- a/iOSOnMac/Makefile
+++ b/iOSOnMac/Makefile
@@ -1,13 +1,42 @@
-all : runner main interpose.dylib
+# Define tools and flags
+CC = clang
+XCRUN = xcrun -sdk iphoneos
+CFLAGS = -arch arm64 -g
+CODESIGN = codesign
+DEVELOPER_ID = "YOUR DEVELOPER ID"
+ENTITLEMENTS = entitlements.xml
 
-interpose.dylib : interpose.c
-	clang interpose.c -arch arm64 -o interpose.dylib -shared -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk
+# Targets
+RUNNER_TARGET = runner
+RUNNER_SRC = runner.c
+INTERPOSE_TARGET = interpose.dylib
+INTERPOSE_SRC = interpose.c
+MAIN_TARGET = main.app/main
+MAIN_SRC = main.c
+APP_DIR = main.app
 
-main : main.c interpose.dylib
-	# Can link against existing frameworks/libraries here by copying them onto ./Frameworks and adding `-F $(PWD)/Frameworks -framework $NAME_OF_FRAMEWORK -Wl,-rpath,$(PWD)/Frameworks
-	clang main.c -arch arm64 -o main -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk interpose.dylib
+# Default target
+all: $(RUNNER_TARGET) $(MAIN_TARGET)
 
-runner : runner.c entitlements.xml
-	clang runner.c -o runner
-	# Replace this identity, find available certificates usign `security find-identity`
-	codesign -s "XXXXXXXXXX" --entitlements entitlements.xml --force runner
+# Build runner
+$(RUNNER_TARGET): $(RUNNER_SRC)
+        $(CC) -o $(RUNNER_TARGET) $(RUNNER_SRC)
+        $(CODESIGN) -s $(DEVELOPER_ID) --entitlements $(ENTITLEMENTS) --force $(RUNNER_TARGET)
+
+# Build main and create app bundle
+$(MAIN_TARGET): $(MAIN_SRC) $(INTERPOSE_TARGET)
+        $(XCRUN) $(CC) $(CFLAGS) -o main $(MAIN_SRC) $(INTERPOSE_TARGET)
+        mkdir -p $(APP_DIR)
+        cp Info.plist $(APP_DIR)/
+        mv main $(APP_DIR)/
+        $(CODESIGN) -s $(DEVELOPER_ID) --entitlements $(ENTITLEMENTS) --force $(APP_DIR)
+
+# Build interpose.dylib
+$(INTERPOSE_TARGET): $(INTERPOSE_SRC)
+        $(XCRUN) $(CC) $(CFLAGS) -o $(INTERPOSE_TARGET) -shared $(INTERPOSE_SRC)
+
+# Clean up build artifacts
+clean:
+        rm -rf $(RUNNER_TARGET) $(INTERPOSE_TARGET) $(APP_DIR)
+
+.PHONY: all clean

--- a/iOSOnMac/interpose.c
+++ b/iOSOnMac/interpose.c
@@ -1,5 +1,3 @@
-// clang interpose.c -arch arm64 -o interpose.dylib -shared -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk
-
 #include <stdio.h>
 #include <unistd.h>
 

--- a/iOSOnMac/runner.c
+++ b/iOSOnMac/runner.c
@@ -1,5 +1,3 @@
-// clang -o runner runner.c
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -10,42 +8,53 @@
 #include <spawn.h>
 #include <sys/wait.h>
 
-#include <mach/mach_init.h>
+#include <mach/mach.h>
 #include <mach/vm_map.h>
 #include <mach/vm_page_size.h>
 
 #define page_align(addr) (vm_address_t)((uintptr_t)(addr) & (~(vm_page_size - 1)))
-
 #define PLATFORM_IOS 2
 
 extern char **environ;
-
 extern int posix_spawnattr_set_platform_np(posix_spawnattr_t*, int, int);
 
 void instrument(pid_t pid) {
     kern_return_t kr;
     task_t task;
 
-    puts("[*] Patching child process to allow dyld interposing...");
+    printf("[*] Instrumenting process with PID %d...\n", pid);
+
+    // Attempt to attach to the task
+    printf("[*] Attempting to attach to task with PID %d...\n", pid);
+    kr = task_for_pid(mach_task_self(), pid, &task);
+    if (kr != KERN_SUCCESS) {
+        fprintf(stderr, "[-] task_for_pid failed with error code: %d\n", kr);
+        fprintf(stderr, "[-] Error description: %s\n", mach_error_string(kr));
+        return;
+    }
+    printf("[+] Successfully attached to task with PID %d\n", pid);
 
     // Find patch point
+    printf("[*] Finding patch point...\n");
     FILE* output = popen("nm -arch arm64e /usr/lib/dyld  | grep _amfi_check_dyld_policy_self", "r");
     unsigned int patch_offset;
     int r = fscanf(output, "%x t _amfi_check_dyld_policy_self", &patch_offset);
+    pclose(output); // Close the pipe after reading
     if (r != 1) {
-        printf("Failed to find offset of _amfi_check_dyld_policy_self in /usr/lib/dyld\n");
+        fprintf(stderr, "[-] Failed to find offset of _amfi_check_dyld_policy_self in /usr/lib/dyld\n");
         return;
     }
-
     printf("[*] _amfi_check_dyld_policy_self at offset 0x%x in /usr/lib/dyld\n", patch_offset);
-   
+
     // Attach to the target process
+    printf("[*] Attaching to target process...\n");
     kr = task_for_pid(mach_task_self(), pid, &task);
     if (kr != KERN_SUCCESS) {
-        printf("task_for_pid failed. Is this binary signed and posesses the com.apple.security.cs.debugger entitlement?\n");
+        fprintf(stderr, "[-] task_for_pid failed: %s\n", mach_error_string(kr));
         return;
     }
 
+    printf("[*] Scanning for /usr/lib/dyld in target's memory...\n");
     vm_address_t dyld_addr = 0;
     int headers_found = 0;
 
@@ -66,14 +75,12 @@ void instrument(pid_t pid) {
         vm_size_t bytes_read;
         kr = vm_read_overwrite(task, addr, 4, (vm_address_t)&header, &bytes_read);
         if (kr != KERN_SUCCESS) {
-            // TODO handle this, some mappings are probably just not readable
-            printf("vm_read_overwrite failed\n");
+            printf("[-] vm_read_overwrite failed\n");
             return;
         }
 
         if (bytes_read != 4) {
-            // TODO handle this properly
-            printf("[-] vm_read read to few bytes\n");
+            printf("[-] vm_read read too few bytes\n");
             return;
         }
 
@@ -100,12 +107,13 @@ void instrument(pid_t pid) {
     vm_address_t patch_addr = dyld_addr + patch_offset;
 
     // VM_PROT_COPY forces COW, probably, see vm_map_protect in vm_map.c
+    printf("[*] Patching _amfi_check_dyld_policy_self...\n");
     kr = vm_protect(task, page_align(patch_addr), vm_page_size, false, VM_PROT_READ | VM_PROT_WRITE | VM_PROT_COPY);
     if (kr != KERN_SUCCESS) {
-        printf("vm_protect failed\n");
+        printf("[-] vm_protect failed\n");
         return;
     }
-    
+
     // MOV X8, 0x5f
     // STR X8, [X1]
     // RET
@@ -113,18 +121,18 @@ void instrument(pid_t pid) {
 
     kr = vm_write(task, patch_addr, (vm_offset_t)code, 12);
     if (kr != KERN_SUCCESS) {
-        printf("vm_write failed\n");
+        printf("[-] vm_write failed\n");
         return;
     }
 
     kr = vm_protect(task, page_align(patch_addr), vm_page_size, false, VM_PROT_READ | VM_PROT_EXECUTE);
     if (kr != KERN_SUCCESS) {
-        printf("vm_protect failed\n");
+        printf("[-] vm_protect failed\n");
         return;
     }
 
     puts("[+] Sucessfully patched _amfi_check_dyld_policy_self");
-} 
+}
 
 int run(const char* binary) {
     pid_t pid;
@@ -140,31 +148,28 @@ int run(const char* binary) {
     rv = posix_spawnattr_setflags(&attr, POSIX_SPAWN_START_SUSPENDED);
     if (rv != 0) {
         perror("posix_spawnattr_setflags");
+        posix_spawnattr_destroy(&attr);
         return -1;
     }
 
     rv = posix_spawnattr_set_platform_np(&attr, PLATFORM_IOS, 0);
     if (rv != 0) {
         perror("posix_spawnattr_set_platform_np");
+        posix_spawnattr_destroy(&attr);
         return -1;
     }
-
-    // Can be useful for fuzzing
-    //setenv("DYLD_INSERT_LIBRARIES", "/usr/lib/libgmalloc.dylib", 1);
 
     char* argv[] = {(char*)binary, NULL};
     rv = posix_spawn(&pid, binary, NULL, &attr, argv, environ);
     if (rv != 0) {
         perror("posix_spawn");
+        posix_spawnattr_destroy(&attr);
         return -1;
     }
-
-    unsetenv("DYLD_INSERT_LIBRARIES");
 
     printf("[+] Child process created with pid: %i\n", pid);
 
     instrument(pid);
-    //getchar();
 
     printf("[*] Sending SIGCONT to continue child\n");
     kill(pid, SIGCONT);
@@ -172,26 +177,23 @@ int run(const char* binary) {
     int status;
     rv = waitpid(pid, &status, 0);
     if (rv == -1) {
-         perror("waitpid");
+        perror("waitpid");
+        posix_spawnattr_destroy(&attr);
         return -1;
     }
 
     printf("[*] Child exited with status %i\n", status);
 
     posix_spawnattr_destroy(&attr);
-
     return 0;
 }
 
 int main(int argc, char* argv[]) {
     if (argc <= 1) {
-        printf("Usage: %s path/to/ios_binary\n", argv[0]);
-        return 0;
+        fprintf(stderr, "Usage: %s path/to/ios_binary\n", argv[0]);
+        return 1;
     }
 
     const char* binary = argv[1];
-
-    printf("[*] Preparing to execute iOS binary %s\n", binary);
-
     return run(binary);
 }


### PR DESCRIPTION
SEE URL https://github.com/xsscx/macos-research/tree/main/code/iOSOnMac for Updated Info

# Updates

This Pull Request does the following:
- Updates the Makefile to Build the Example Project on macOS 14.1.1 | 23B81
- Adds some print statements to runner
- Removes legacy compile comments at top of interpose.c

## iOS App Tree Example
```
tree main.app
main.app
├── Info.plist
├── _CodeSignature
│   └── CodeResources
└── main

2 directories, 3 files
```

## Testing with Example Code
```
/runner main.app/main
[+] Child process created with pid: 42525
[*] Instrumenting process with PID 42525...
[*] Attempting to attach to task with PID 42525...
[+] Successfully attached to task with PID 42525
[*] Finding patch point...
[*] _amfi_check_dyld_policy_self at offset 0x6e728 in /usr/lib/dyld
[*] Attaching to target process...
[*] Scanning for /usr/lib/dyld in target's memory...
[*] /usr/lib/dyld mapped at 0x104348000
[*] Patching _amfi_check_dyld_policy_self...
[+] Sucessfully patched _amfi_check_dyld_policy_self
[*] Sending SIGCONT to continue child
Hello World from iOS!
[*] Child exited with status 0
```

### Testing with Apple Security Research Device Tools | Release 20C80
```
./runner hello.app/hello
[+] Child process created with pid: 42536
[*] Instrumenting process with PID 42536...
[*] Attempting to attach to task with PID 42536...
[+] Successfully attached to task with PID 42536
[*] Finding patch point...
[*] _amfi_check_dyld_policy_self at offset 0x6e728 in /usr/lib/dyld
[*] Attaching to target process...
[*] Scanning for /usr/lib/dyld in target's memory...
[*] /usr/lib/dyld mapped at 0x104970000
[*] Patching _amfi_check_dyld_policy_self...
[+] Sucessfully patched _amfi_check_dyld_policy_self
[*] Sending SIGCONT to continue child
Hello researcher from pid 42536!
[*] Child exited with status 0
```
### Simple-Server Example | 20C80
```
lldb -- ./runner simple-server.app/simple-server
(lldb) target create "./runner"
Current executable set to '/Users/xss/tmp/iOSOnMac/runner' (arm64).
(lldb) settings set -- target.run-args  "simple-server.app/simple-server"
(lldb) r
Process 28561 launched: '/Users/xss/tmp/iOSOnMac/runner' (arm64)
[+] Child process created with pid: 28565
[*] Instrumenting process with PID 28565...
[*] Attempting to attach to task with PID 28565...
[+] Successfully attached to task with PID 28565
[*] Finding patch point...
[*] _amfi_check_dyld_policy_self at offset 0x6e728 in /usr/lib/dyld
[*] Attaching to target process...
[*] Scanning for /usr/lib/dyld in target's memory...
[*] /usr/lib/dyld mapped at 0x100018000
[*] Patching _amfi_check_dyld_policy_self...
[+] Sucessfully patched _amfi_check_dyld_policy_self
[*] Sending SIGCONT to continue child
2023-11-25 10:00:38.526027-0500 simple-server[28565:155085] [simple-server] Hello! I'm simple-server from the example cryptex!
2023-11-25 10:00:38.526057-0500 simple-server[28565:155085] [simple-server] I'm about to bind to 0.0.0.0:7777
2023-11-25 10:00:38.526125-0500 simple-server[28565:155085] [simple-server] I'm about to listen on fd: 3
2023-11-25 10:00:38.526143-0500 simple-server[28565:155085] [simple-server] Waiting for a client to connect...
2023-11-25 10:00:43.143281-0500 simple-server[28565:155085] [simple-server] A client has connected!
2023-11-25 10:00:43.143323-0500 simple-server[28565:155085] [simple-server] Hello! I'm process 28565
2023-11-25 10:00:43.143363-0500 simple-server[28565:155085] [simple-server] Waiting for a client to connect...
```
#### Simple-Server Check | 20C80 Example
```
telnet 127.0.0.1 7777
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
Hello! I'm process 28668
The environment variable CRYPTEX_MOUNT_PATH  contains: "/Users/xss/Documents/iphone11/com.example.cryptex.dstroot/usr/bin/sh"
```
### Platform Checks
```
otool -l main.app/main | grep platform
 platform 2
otool -l hello.app/hello | grep platform
 platform 2
otool -l interpose.dylib | grep platform
 platform 2
otool -l runner | grep platform
 platform 1
```