### PR TITLE
iOSOnMac compatibility improvement

### DIFF
--- a/iOSOnMac/Makefile
+++ b/iOSOnMac/Makefile
@@ -3,9 +3,8 @@ all : runner main interpose.dylib
 interpose.dylib : interpose.c
 	clang interpose.c -arch arm64 -o interpose.dylib -shared -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk
 
-main : main.c interpose.dylib
-	# Can link against existing frameworks/libraries here by copying them onto ./Frameworks and adding `-F $(PWD)/Frameworks -framework $NAME_OF_FRAMEWORK -Wl,-rpath,$(PWD)/Frameworks
-	clang main.c -arch arm64 -o main -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk interpose.dylib
+main : main.c
+	clang main.c -arch arm64 -o main -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk
 
 runner : runner.c entitlements.xml
 	clang runner.c -o runner

--- a/iOSOnMac/Makefile
+++ b/iOSOnMac/Makefile
@@ -1,12 +1,28 @@
-all : runner main interpose.dylib
+CLANG_MACOS := xcrun --sdk macosx -r clang
+CLANG_IOS := xcrun --sdk iphoneos -r clang
+IOS_SYSROOT := $(shell xcrun --sdk iphoneos --show-sdk-path)
+CLANG_IOS_FLAGS := -arch arm64 -isysroot $(IOS_SYSROOT)
 
-interpose.dylib : interpose.c
-	clang interpose.c -arch arm64 -o interpose.dylib -shared -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk
+.PHONY: all clean
+all: runner main interpose.dylib
 
-main : main.c
-	clang main.c -arch arm64 -o main -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk
+interpose.dylib: interpose.c
+	$(CLANG_IOS) $(CLANG_IOS_FLAGS) -shared -o interpose.dylib interpose.c
 
-runner : runner.c entitlements.xml
-	clang runner.c -o runner
-	# Replace this identity, find available certificates usign `security find-identity`
-	codesign -s "XXXXXXXXXX" --entitlements entitlements.xml --force runner
+main: main.c
+	$(CLANG_IOS) $(CLANG_IOS_FLAGS) -o main main.c
+
+runner: runner.c entitlements.xml
+	$(CLANG_MACOS) -o runner runner.c
+	@if [ -n "$(IDENTITY)" ]; then \
+		codesign -s "$(IDENTITY)" --entitlements entitlements.xml --force runner; \
+	elif command -v ldid >/dev/null 2>&1; then \
+		ldid -Sentitlements.xml runner; \
+	else \
+		echo "Error: No signing method available. Set IDENTITY or install ldid."; \
+		echo "Find available certificates using: security find-identity"; \
+		exit 1; \
+	fi
+
+clean:
+	@rm -f runner interpose.dylib main

--- a/iOSOnMac/runner.c
+++ b/iOSOnMac/runner.c
@@ -38,7 +38,7 @@ void instrument(pid_t pid) {
     }
 
     printf("[*] _amfi_check_dyld_policy_self at offset 0x%x in /usr/lib/dyld\n", patch_offset);
-   
+
     // Attach to the target process
     kr = task_for_pid(mach_task_self(), pid, &task);
     if (kr != KERN_SUCCESS) {
@@ -105,7 +105,7 @@ void instrument(pid_t pid) {
         printf("vm_protect failed\n");
         return;
     }
-    
+
     // MOV X8, 0x5f
     // STR X8, [X1]
     // RET
@@ -124,7 +124,7 @@ void instrument(pid_t pid) {
     }
 
     puts("[+] Sucessfully patched _amfi_check_dyld_policy_self");
-} 
+}
 
 int run(const char* binary) {
     pid_t pid;
@@ -151,6 +151,7 @@ int run(const char* binary) {
 
     // Can be useful for fuzzing
     //setenv("DYLD_INSERT_LIBRARIES", "/usr/lib/libgmalloc.dylib", 1);
+    setenv("DYLD_IN_CACHE", "0", 1);
 
     char* argv[] = {(char*)binary, NULL};
     rv = posix_spawn(&pid, binary, NULL, &attr, argv, environ);
@@ -160,6 +161,7 @@ int run(const char* binary) {
     }
 
     unsetenv("DYLD_INSERT_LIBRARIES");
+    unsetenv("DYLD_IN_CACHE");
 
     printf("[+] Child process created with pid: %i\n", pid);
 

--- a/iOSOnMac/runner.c
+++ b/iOSOnMac/runner.c
@@ -152,6 +152,7 @@ int run(const char* binary) {
     // Can be useful for fuzzing
     //setenv("DYLD_INSERT_LIBRARIES", "/usr/lib/libgmalloc.dylib", 1);
     setenv("DYLD_IN_CACHE", "0", 1);
+    setenv("DYLD_INSERT_LIBRARIES", "interpose.dylib", 1);
 
     char* argv[] = {(char*)binary, NULL};
     rv = posix_spawn(&pid, binary, NULL, &attr, argv, environ);


### PR DESCRIPTION
This pull request introduces updates to the `iOSOnMac` project, focusing on compatibility improvements and build process improvements.

## Key Changes

1. MacOS Compatibility Fix
    - Issue: Interposing did not work properly on newer macOS versions since `dyld` unmapped itself.
    - Solution: Disabled `dyld` shared cache for internal components.
    - Implementation: Added environment variables `DYLD_IN_CACHE=0` and `DYLD_INSERT_LIBRARIES=interpose.dylib` in `runner.c` before spawning the child process.
    - References: Addresses issues #5 and #9. 
3. Build Process Improvements
    - Improved overall readability.
    - Added a `clean` target to remove build artifacts.
    - Added optional support for signing with `ldid`.